### PR TITLE
chore: update staging bucket to dev

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -46,9 +46,9 @@ templated_files = gcp.CommonTemplates().py_library()
 s.move(templated_files / ".kokoro")
 s.replace(
     ".kokoro/docs/common.cfg",
-    """# Push non-cloud library docs to `docs-staging-v2-staging` instead of the
+    """# Push non-cloud library docs to `docs-staging-v2-dev` instead of the
     # Cloud RAD bucket `docs-staging-v2`
-    value: \"docs-staging-v2-staging\"""",
+    value: \"docs-staging-v2-dev\"""",
     """# Allow publishing docs for this library.
     value: \"docs-staging-v2\"""",
 )


### PR DESCRIPTION
The staging bucket is no longer used (b/374954111). Changing to dev instead.

Note: This PR should NOT be submitted and/or approved until https://github.com/googleapis/synthtool/pull/2026 is merged.

Towards b/374991608 🦕